### PR TITLE
correct README copy-paste error

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Example
 secure_jwt_example = "eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt.cGxlLmNvbS9pc19yb290Ijp0cnVlfQ.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
 
 # verify with default algorithm, HMAC SHA256
-{:ok, verified_claims} = JsonWebToken.verify(secure_jwt_example, %{key: "gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr9C"})
+{:ok, verified_claims} = JwtClaims.verify(secure_jwt_example, %{key: "gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr9C"})
 
 ```
 


### PR DESCRIPTION
Should use JwtClaims rather than JsonWebToken to verify the jwt

@garyf thanks for the great work
