### PR TITLE
Suppress unused variable warning

### DIFF
--- a/lib/jwt_claims/claim/exp.ex
+++ b/lib/jwt_claims/claim/exp.ex
@@ -21,7 +21,7 @@ defmodule JwtClaims.Claim.Exp do
   until the specified UTC date/time; non-integer values may be used
   """
   def reject?(numeric_date, options \\ %{}) # options for leeway_seconds (pending implementation)
-  def reject?(numeric_date, options) when is_number(numeric_date) do
+  def reject?(numeric_date, _options) when is_number(numeric_date) do
     numeric_date <= Util.time_now
   end
   def reject?(_, _), do: true

--- a/lib/jwt_claims/claim/nbf.ex
+++ b/lib/jwt_claims/claim/nbf.ex
@@ -21,7 +21,7 @@ defmodule JwtClaims.Claim.Nbf do
   until the specified UTC date/time; non-integer values may be used
   """
   def reject?(numeric_date, options \\ %{})
-  def reject?(numeric_date, options) when is_number(numeric_date) do
+  def reject?(numeric_date, _options) when is_number(numeric_date) do
     numeric_date > Util.time_now
   end
   def reject?(_, _), do: true


### PR DESCRIPTION
Elixir 1.3 warns about the unused vars.

```
==> jwt_claims
Compiling 11 files (.ex)
warning: variable options is unused
  lib/jwt_claims/claim/exp.ex:24

warning: variable options is unused
  lib/jwt_claims/claim/nbf.ex:24
```
